### PR TITLE
Improve handling around required flags

### DIFF
--- a/example_command.go
+++ b/example_command.go
@@ -23,16 +23,18 @@ func newExampleCommand() *cli.Command {
 		Before: command.validate,
 		Action: command.execute,
 		Flags: []cli.Flag{
-			&cli.StringFlag{Destination: &command.ExampleFlag, Name: "flag", EnvVars: envVars("EXAMPLE_FLAG"), Value: "foo", Usage: "a demonstration how to configure the command"},
+			&cli.StringFlag{Destination: &command.ExampleFlag, Name: "flag", EnvVars: envVars("EXAMPLE_FLAG"), Value: "foo", Usage: "a demonstration how to configure the command", Required: true},
 		},
 	}
 }
 
 func (c *exampleCommand) validate(context *cli.Context) error {
+	_ = LogMetadata(context)
 	log := AppLogger(context).WithName(exampleCommandName)
 	log.V(1).Info("validating config")
-	if c.ExampleFlag == "" {
-		return fmt.Errorf("option cannot be empty: %s", "flag")
+	// The `Required` property in the StringFlag above already checks if it's non-empty.
+	if len(c.ExampleFlag) <= 2 {
+		return fmt.Errorf("option needs at least 3 characters: %s", "flag")
 	}
 	return nil
 }

--- a/example_command_test.go
+++ b/example_command_test.go
@@ -14,7 +14,7 @@ func TestExampleCommand_Validate(t *testing.T) {
 	}{
 		// TODO: test cases
 		"GivenEmptyFlag_ThenExpectError": {
-			expectedError: "option cannot be empty: flag",
+			expectedError: "option needs at least 3 characters: flag",
 		},
 		"GivenValidConfig_ThenExpectNoError": {
 			givenExampleFlag: "test",

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"sync/atomic"
 	"testing"
 
@@ -14,7 +15,7 @@ func newAppContext(t *testing.T) *cli.Context {
 	logger := zapr.NewLogger(zaptest.NewLogger(t))
 	instance := &atomic.Value{}
 	instance.Store(logger)
-	return cli.NewContext(&cli.App{}, nil, &cli.Context{
+	return cli.NewContext(&cli.App{}, flag.NewFlagSet("", flag.ContinueOnError), &cli.Context{
 		Context: context.WithValue(context.Background(), loggerContextKey{}, instance),
 	})
 }


### PR DESCRIPTION
## Summary

* If a required flag was not given, it would show usage without displaying the error
* It turns out determining whether to print Metadata based on the arguments is nigh impossible. So let's leave that up to the subcommands

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
