### PR TITLE
Fix: Build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build: build-bin build-docker ## All-in-one build
 .PHONY: build-bin
 build-bin: export CGO_ENABLED = 0
 build-bin: fmt vet ## Build binary
-	@go build -o $(BIN_FILENAME) ./...
+	@go build -o $(BIN_FILENAME) .
 
 .PHONY: build-docker
 build-docker: build-bin ## Build docker image


### PR DESCRIPTION
Fix the build command. The previous command doesn't actually work if there is a "pkg" dir with more code, instead it errors with an obscure message. This command appears to work.