### PR TITLE
Fix env parsing if prefix is set to empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,8 +24,9 @@ var (
 	appLongName = "a generic bootstrapping project"
 
 	// TODO: Adjust or clear env var prefix
-	// envPrefix is the global prefix to use for the keys in environment variables
-	envPrefix = "BOOTSTRAP"
+	// envPrefix is the global prefix to use for the keys in environment variables.
+	// Include a delimiter like `_` if required.
+	envPrefix = "BOOTSTRAP_"
 )
 
 func main() {
@@ -96,7 +97,7 @@ func rootAction(hasSubcommands bool) func(context *cli.Context) error {
 
 // env combines envPrefix with given suffix delimited by underscore.
 func env(suffix string) string {
-	return envPrefix + "_" + suffix
+	return envPrefix + suffix
 }
 
 // envVars combines envPrefix with each given suffix delimited by underscore.


### PR DESCRIPTION
## Summary

Fixes the case where the env variable prefix is set to empty, it wouldn't use `_` as a prefix (e.g. `_LOG_LEVEL`)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
