### PR TITLE
Disable CodeClimate Golang linters

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,11 +3,11 @@ plugins:
   shellcheck:
     enabled: true
   govet:
-    enabled: true
+    enabled: false
   gofmt:
-    enabled: true
+    enabled: false
   golint:
-    enabled: true
+    enabled: false
   fixme:
     enabled: true
 exclude_patterns:


### PR DESCRIPTION
CodeClimate Go support is dead and still can't handle generics.

https://codeclimate.com/github/appuio/appuio-cloud-reporting/pull/88

![image](https://user-images.githubusercontent.com/1249775/193230093-2cc677f0-f4be-44ff-bb30-3b98e1c534b3.png)

https://github.com/codeclimate/codeclimate/issues/1063

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
