### PR TITLE
Run golangci-lint from makefile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,3 @@ jobs:
 
       - name: Run linters
         run: make lint
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest


### PR DESCRIPTION


## Summary

* Run golangci-lint from makefile instead of GH actions, to avoid different behaviour of local run vs GH.
* Incorporates experiences made in https://github.com/vshn/provider-exoscale/pull/48 and https://github.com/vshn/provider-exoscale/pull/47

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
