### PR TITLE
Update setup-go action & improve usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,19 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Determine Go version from go.mod
-        run: echo "GO_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV
-
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
 
       - name: Run build
         run: make build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+
     - name: Configure Git
       run: |
         git config user.name "Antora via GitHub Actions"
@@ -26,10 +27,12 @@ jobs:
       with:
         input_string: ${{ github.ref }}
         version_extractor_regex: '\/v(.*)$'
+
     - name: Set variables
       run: |
         echo "MINOR_VERSION=${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}" >> $GITHUB_ENV
         echo "BRANCH_NAME=docs/v${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}" >> $GITHUB_ENV
+
     - name: Set branch name for Prerelease
       if: ${{ steps.semver.outputs.prerelease != '' }}
       run: echo "BRANCH_NAME=${{ env.BRANCH_NAME }}-rc" >> $GITHUB_ENV
@@ -37,9 +40,11 @@ jobs:
     - name: Checkout remote branch if exists
       run: git checkout ${{ env.BRANCH_NAME }}
       continue-on-error: true
+
     - name: Rebase if possible
       run: git rebase ${GITHUB_REF##*/} ${{ env.BRANCH_NAME }}
       continue-on-error: true
+
     - name: Create new branch if not existing
       run: git switch --create ${{ env.BRANCH_NAME }}
       continue-on-error: true
@@ -47,6 +52,7 @@ jobs:
     - name: Patch Antora file for Release
       run: yq eval 'del(.prerelease) | del (.display_version) | .version = "${{ env.MINOR_VERSION }}"' -i docs/antora.yml
       if: ${{ steps.semver.outputs.prerelease == '' }}
+
     - name: Patch Antora file for Prerelease
       run: yq eval 'del (.display_version) | .version = "${{ env.MINOR_VERSION }}", .prerelease = "-${{ steps.semver.outputs.prerelease }}"' -i docs/antora.yml
       if: ${{ steps.semver.outputs.prerelease != '' }}
@@ -54,6 +60,7 @@ jobs:
     - name: Commit
       run: git commit --all --message "Update version for Antora"
       continue-on-error: true
+
     - name: Push
       run: git push --atomic --force --set-upstream origin ${{ env.BRANCH_NAME }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,19 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Determine Go version from go.mod
-        run: echo "GO_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV
-
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
 
       - name: Run linters
         run: make lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,25 +13,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine Go version from go.mod
-        run: echo "GO_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV
-
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,19 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Determine Go version from go.mod
-        run: echo "GO_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV
-
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
 
       - name: Run tests
         run: make test


### PR DESCRIPTION
- bump action setup-go to v4
- setup-go can determine the Go version from a `go.mod` file itself [1]
- setup-go sets up caching itself [2]

[1]: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file
[2]: https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs